### PR TITLE
Updating to latest Fastly provider and cleaning up config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run:
           name: Install Alpine dependencies
-          command: apk add bash jq
+          command: apk add bash jq curl
       - run:
           name: Setup Test Deploy
           command: mv -f terraform/test_override.tf terraform/domains_override.tf
@@ -87,7 +87,7 @@ jobs:
       - checkout
       - run:
           name: Install Alpine dependencies
-          command: apk add bash jq
+          command: apk add bash jq curl
       - run:
           name: Setup Production Deploy
           command: rm terraform/test_override.tf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       - run:
           name: Import State from Test
           command: terraform import -config=terraform/ fastly_service_v1.app 2HgcjZpZ4vG53E5gVKIG0L
+      - run: terraform import -config="fastly/terraform" fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
       - run:
           name: Deploy to Test
           command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
@@ -97,6 +98,7 @@ jobs:
       - run:
           name: Import State from Production
           command: terraform import -config=terraform/ fastly_service_v1.app 6DQQc0HH9BNwvlqQgXOk7H
+      - run: terraform import -config="fastly/terraform" fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
       - run:
           name: Deploy to Production
           command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
           name: Import State from Test
           command: terraform import -config=terraform/ fastly_service_v1.app 2HgcjZpZ4vG53E5gVKIG0L
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
+      - run: terraform state rm fastly_service_dictionary_items_v1.items
       - run:
           name: Deploy to Test
           command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/
@@ -99,6 +100,7 @@ jobs:
           name: Import State from Production
           command: terraform import -config=terraform/ fastly_service_v1.app 6DQQc0HH9BNwvlqQgXOk7H
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
+      - run: terraform state rm fastly_service_dictionary_items_v1.items
       - run:
           name: Deploy to Production
           command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
       - run:
           name: Deploy to Test
-          command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
+          command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/
 
   verify_test:
     docker:
@@ -101,7 +101,7 @@ jobs:
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
       - run:
           name: Deploy to Production
-          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
+          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/
 
   verify_production:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,9 @@ jobs:
           name: Import State from Test
           command: terraform import -config=terraform/ fastly_service_v1.app 2HgcjZpZ4vG53E5gVKIG0L
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
-      - run: terraform state rm fastly_service_dictionary_items_v1.items
       - run:
           name: Deploy to Test
-          command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/
+          command: .circleci/do-exclusively.sh terraform apply --auto-approve terraform/
 
   verify_test:
     docker:
@@ -100,10 +99,9 @@ jobs:
           name: Import State from Production
           command: terraform import -config=terraform/ fastly_service_v1.app 6DQQc0HH9BNwvlqQgXOk7H
       - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
-      - run: terraform state rm fastly_service_dictionary_items_v1.items
       - run:
           name: Deploy to Production
-          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key="$FT-Origami-Key" terraform/
+          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve terraform/
 
   verify_production:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Import State from Test
           command: terraform import -config=terraform/ fastly_service_v1.app 2HgcjZpZ4vG53E5gVKIG0L
-      - run: terraform import -config="fastly/terraform" fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
+      - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "2HgcjZpZ4vG53E5gVKIG0L/0h5jWqqz7Mxuv41G4Fcev2"
       - run:
           name: Deploy to Test
           command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: Import State from Production
           command: terraform import -config=terraform/ fastly_service_v1.app 6DQQc0HH9BNwvlqQgXOk7H
-      - run: terraform import -config="fastly/terraform" fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
+      - run: terraform import -config=terraform/ fastly_service_dictionary_items_v1.items "6DQQc0HH9BNwvlqQgXOk7H/5dNU2c7TTuaygdgFDyLtl6"
       - run:
           name: Deploy to Production
           command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           command: terraform import -config=terraform/ fastly_service_v1.app 2HgcjZpZ4vG53E5gVKIG0L
       - run:
           name: Deploy to Test
-          command: .circleci/do-exclusively.sh terraform apply --auto-approve terraform/
+          command: .circleci/do-exclusively.sh terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
 
   verify_test:
     docker:
@@ -99,7 +99,7 @@ jobs:
           command: terraform import -config=terraform/ fastly_service_v1.app 6DQQc0HH9BNwvlqQgXOk7H
       - run:
           name: Deploy to Production
-          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve terraform/
+          command: .circleci/do-exclusively.sh --branch master terraform apply --auto-approve -var FT-Origami-Key=$FT-Origami-Key terraform/
 
   verify_production:
     docker:

--- a/README.md
+++ b/README.md
@@ -27,14 +27,4 @@ export FT_ORIGAMI_KEY=
 
 To authenticate requests between `www.ft.com` Fastly and our Fastly service , our service hecks for a shared secret added to requests.
 
-The secret is stored in a VCL Snippet, which can be seen in the Fastly UI. It is kept out of this repository because it is a secret.
-
-# FT Tooling Team
-
-The tooling team manage several chunks of VCL to enforce WAF, and two shared ACLs.
-
-Both `ft_manage_blacklist` and `FT_Internal_IP_Whitelist` are ACLs that we shouldn't have to manage, but should be aware of, and enforce.
-
-For WAF, there's nothing in the UI to view yet. You will see the addition of some logging and condition artifacts in both the UI and Terraform, until there is 100% for WAF in Terraform.
-
-With `req.http.bypass_waf`, this **must** be set explicitly to prevent a means of skipping WAF.
+The secret is stored in a Fastly Edge Dictionary. 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ export FT_ORIGAMI_KEY=
 
 To authenticate requests between `www.ft.com` Fastly and our Fastly service , our service hecks for a shared secret added to requests.
 
-The secret is stored in a Fastly Edge Dictionary. 
+The secret is stored in a Fastly Edge Dictionary. The Terraform configuration makes the dictionary, but we add the item to the dictionary via the Fastly UI manually.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,25 +82,6 @@ resource "fastly_service_v1" "app" {
     destination = "http.Proxy"
   }
 
-  #
-  # TODO: Uncomment this when the ACLs are added to our Fastly service by the FT Tooling team
-  #
-  // WAF Configuration.
-  # condition {
-  #   name      = "Waf_Prefetch"
-  #   statement = "!req.backend.is_shield && !req.http.bypass_waf"
-  #   type      = "PREFETCH"
-  #   priority  = 10
-  # }
-
-
-  # response_object {
-  #   name     = "WAF_Response"
-  #   status   = 403
-  #   response = "Forbidden"
-  #   content  = "{ \"Access Denied\" : \"} req.http.x_request_id {\" }"
-  # }
-
   // Custom VCL.
   vcl {
     name    = "main.vcl"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,27 +104,27 @@ resource "fastly_service_v1" "app" {
   // Custom VCL.
   vcl {
     name    = "main.vcl"
-    content = "${file("${path.module}/../vcl/main.vcl")}"
+    content = file("${path.module}/../vcl/main.vcl")
     main    = true
   }
   vcl {
     name    = "caching.vcl"
-    content = "${file("${path.module}/../vcl/caching.vcl")}"
+    content = file("${path.module}/../vcl/caching.vcl")
   }
   vcl {
     name    = "fastly-boilerplate-begin.vcl"
-    content = "${file("${path.module}/../vcl/fastly-boilerplate-begin.vcl")}"
+    content = file("${path.module}/../vcl/fastly-boilerplate-begin.vcl")
   }
   vcl {
     name    = "fastly-boilerplate-end.vcl"
-    content = "${file("${path.module}/../vcl/fastly-boilerplate-end.vcl")}"
+    content = file("${path.module}/../vcl/fastly-boilerplate-end.vcl")
   }
   vcl {
     name    = "multi-region-routing.vcl"
-    content = "${file("${path.module}/../vcl/multi-region-routing.vcl")}"
+    content = file("${path.module}/../vcl/multi-region-routing.vcl")
   }
   vcl {
     name    = "surrogate-keys.vcl"
-    content = "${file("${path.module}/../vcl/surrogate-keys.vcl")}"
+    content = file("${path.module}/../vcl/surrogate-keys.vcl")
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "fastly" {
-  version = "0.1.2"
+  version = "0.11.1"
 }
 
 resource "fastly_service_v1" "app" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,6 +114,6 @@ resource "fastly_service_dictionary_items_v1" "items" {
   dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
 
   items = {
-    "FT-Origami-Key": var.FT-Origami-Key
+    "FT-Origami-Key" : var.FT-Origami-Key
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,9 +2,6 @@ provider "fastly" {
   version = "0.11.1"
 }
 
-variable "FT-Origami-Key" {
-}
-
 locals {
   dictionary_name = "secrets"
 }
@@ -118,6 +115,9 @@ resource "fastly_service_dictionary_items_v1" "items" {
   dictionary_id = { for d in fastly_service_v1.app.dictionary : d.name => d.dictionary_id }[local.dictionary_name]
 
   items = {
-    "FT-Origami-Key" : var.FT-Origami-Key
+  }
+
+  lifecycle {
+    ignore_changes = [items, ]
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,18 +5,6 @@ provider "fastly" {
 resource "fastly_service_v1" "app" {
   name = "Origami Build Service (github.com/Financial-Times/origami-build-service)"
 
-  // Logging to S3, see https://docs.fastly.com/guides/streaming-logs/custom-log-formats for formats.
-  s3logging {
-    name           = "Request Logs"
-    bucket_name    = "ft-cdn-logs"
-    path           = "/origami-build-service.in.ft.com/production/"
-    period         = "3600"
-    gzip_level     = 9
-    format_version = 2
-    format         = "%v %{server.region}V [%{%Y-%m-%d %H:%M:%S}t.%{msec_frac}t] \"%r\" %>s %{req.bytes_read}V %{resp.bytes_written}V %{time.elapsed.msec}V %{tls.client.protocol}V %{fastly_info.state}V %{req.http.Fastly-FF}V"
-    message_type   = "blank"
-  }
-
   // Backend and healthcheck for the eu.
   backend {
     name                  = "origin_eu"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,6 +2,9 @@ provider "fastly" {
   version = "0.11.1"
 }
 
+variable "FT-Origami-Key" {
+}
+
 resource "fastly_service_v1" "app" {
   name = "Origami Build Service (github.com/Financial-Times/origami-build-service)"
 
@@ -99,5 +102,18 @@ resource "fastly_service_v1" "app" {
   vcl {
     name    = "surrogate-keys.vcl"
     content = file("${path.module}/../vcl/surrogate-keys.vcl")
+  }
+
+  dictionary {
+    name = "secrets"
+  }
+}
+
+resource "fastly_service_dictionary_items_v1" "items" {
+  service_id    = "${fastly_service_v1.app.id}"
+  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
+
+  items = {
+    "FT-Origami-Key": var.FT-Origami-Key
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,14 +74,6 @@ resource "fastly_service_v1" "app" {
     content_types = ["text/html", "application/x-javascript", "text/css", "application/javascript", "text/javascript", "application/json", "application/vnd.ms-fontobject", "application/x-font-opentype", "application/x-font-truetype", "application/x-font-ttf", "application/xml", "font/eot", "font/opentype", "font/otf", "image/svg+xml", "image/vnd.microsoft.icon", "text/plain", "text/xml"]
   }
 
-  // Remove the Proxy header, CVE-2016-5385
-  header {
-    name        = "Delete Proxy"
-    action      = "delete"
-    type        = "request"
-    destination = "http.Proxy"
-  }
-
   // Custom VCL.
   vcl {
     name    = "main.vcl"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,10 @@ provider "fastly" {
 variable "FT-Origami-Key" {
 }
 
+locals {
+  dictionary_name = "secrets"
+}
+
 resource "fastly_service_v1" "app" {
   name = "Origami Build Service (github.com/Financial-Times/origami-build-service)"
 
@@ -105,13 +109,13 @@ resource "fastly_service_v1" "app" {
   }
 
   dictionary {
-    name = "secrets"
+    name = local.dictionary_name
   }
 }
 
 resource "fastly_service_dictionary_items_v1" "items" {
-  service_id    = "${fastly_service_v1.app.id}"
-  dictionary_id = "${ { for dictionary in fastly_service_v1.app.dictionary : dictionary.name => dictionary.dictionary_id }["secrets"]}"
+  service_id    = fastly_service_v1.app.id
+  dictionary_id = { for d in fastly_service_v1.app.dictionary : d.name => d.dictionary_id }[local.dictionary_name]
 
   items = {
     "FT-Origami-Key" : var.FT-Origami-Key

--- a/terraform/test_override.tf
+++ b/terraform/test_override.tf
@@ -5,16 +5,4 @@ resource "fastly_service_v1" "app" {
   domain {
     name = "origami-build-service-cdn-test.in.ft.com"
   }
-
-  // Logging to S3, see https://docs.fastly.com/guides/streaming-logs/custom-log-formats for formats.
-  s3logging {
-    name           = "Request Logs"
-    bucket_name    = "ft-cdn-logs"
-    path           = "/origami-build-service-cdn-test.in.ft.com/test/"
-    period         = "300"
-    gzip_level     = 9
-    format_version = 2
-    format         = "%v [%{%Y-%m-%d %H:%M:%S}t.%{msec_frac}t] \"%r\" %>s %{req.bytes_read}V %{resp.bytes_written}V %{time.elapsed.msec}V %{tls.client.protocol}V %{fastly_info.state}V %{req.http.Fastly-FF}V"
-    message_type   = "blank"
-  }
 }

--- a/test/purge.spec.js
+++ b/test/purge.spec.js
@@ -6,6 +6,6 @@ describe("purge", () => {
   it("rejects unauthorized purge requests", () => {
     return request
       .purge("https://origami-build-service.in.ft.com/v2")
-      .then(res => expect(res).to.have.status(400));
+      .then(res => expect(res).to.have.status(401));
   });
 });


### PR DESCRIPTION
I've removed the logging to S3, since those buckets have been deleted a long time ago.

I've updated the way we stored a shared-secret to use an edge-dictionary instead of a vcl snippet.

`curl` was removed from the terraform images, so we now install it explicitly.

Fastly changed their response code from 400 to 401 for unauthed purge requests, I updated our test to use 401.